### PR TITLE
Add mcfunction language association to .bolt files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bolt linguist-language=mcfunction


### PR DESCRIPTION
- Added `mcfunction` language association for `.bolt` files.

This effectively enables syntax highlighting improving readability ;)